### PR TITLE
Clean shutdown and better error messages

### DIFF
--- a/metrics/Cargo.lock
+++ b/metrics/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio",
+ "mio 0.8.2",
  "num_cpus",
  "socket2",
  "tokio",
@@ -147,7 +147,7 @@ dependencies = [
  "ahash",
  "bytes",
  "bytestring",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cookie",
  "derive_more",
  "encoding_rs",
@@ -230,7 +230,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -313,6 +313,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -381,7 +387,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -423,7 +429,7 @@ version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -449,6 +455,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "firestorm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,7 +478,7 @@ version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -496,6 +514,41 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures-channel"
@@ -552,7 +605,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
@@ -690,12 +743,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -729,6 +811,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +831,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -779,7 +877,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -803,6 +901,7 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "log",
+ "notify",
  "prometheus",
  "reqwest",
  "serde",
@@ -828,16 +927,59 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow 0.2.2",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
- "miow",
+ "miow 0.3.7",
  "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio 0.6.23",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -846,7 +988,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -868,12 +1010,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "notify"
+version = "4.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio 0.6.23",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -908,7 +1079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -970,12 +1141,12 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -984,7 +1155,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1042,7 +1213,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
  "memchr",
@@ -1128,7 +1299,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1183,13 +1354,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1276,7 +1456,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
 ]
@@ -1309,7 +1489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1335,12 +1515,12 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "libc",
  "redox_syscall",
  "remove_dir_all",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1420,7 +1600,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.2",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.0",
@@ -1428,7 +1608,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1492,7 +1672,7 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-core",
@@ -1565,6 +1745,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,7 +1783,7 @@ version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -1617,7 +1808,7 @@ version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1664,6 +1855,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -1671,6 +1868,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1684,7 +1887,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1742,7 +1945,17 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -20,3 +20,4 @@ lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 clap = { version = "3", features = ["env", "cargo"] }
+notify = "4.0.17"

--- a/metrics/src/collectors/metadata.rs
+++ b/metrics/src/collectors/metadata.rs
@@ -23,7 +23,7 @@ pub struct MetadataCheckRequest {
 }
 
 impl MetadataCheckRequest {
-    fn GetInconsistentMetadata() -> Self {
+    fn get_inconsistent_metadata() -> Self {
         MetadataCheckRequest {
             request_type: "get_inconsistent_metadata".to_string(),
             args: HashMap::new(),
@@ -41,7 +41,7 @@ pub(crate) async fn check_metadata(cfg: &Configuration) {
     let client = reqwest::Client::new();
     let metadata_check = client
         .post(format!("{}/v1/metadata", cfg.hasura_addr))
-        .json(&MetadataCheckRequest::GetInconsistentMetadata())
+        .json(&MetadataCheckRequest::get_inconsistent_metadata())
         .header("x-hasura-admin-secret", cfg.hasura_admin.to_owned())
         .send()
         .await;

--- a/metrics/src/collectors/mod.rs
+++ b/metrics/src/collectors/mod.rs
@@ -1,4 +1,5 @@
-use crate::{Configuration};
+use std::sync::mpsc;
+use crate::{Configuration, util};
 
 mod sql;
 mod health;
@@ -7,7 +8,7 @@ mod scheduled_events;
 mod cron_triggers;
 mod event_triggers;
 
-pub(crate) async fn run_metadata_collector(cfg: &Configuration) -> std::io::Result<()> {
+pub(crate) async fn run_metadata_collector(cfg: &Configuration, rx: &mpsc::Receiver<()>) -> std::io::Result<()> {
     loop {
         tokio::join!(
             health::check_health(cfg),
@@ -16,6 +17,12 @@ pub(crate) async fn run_metadata_collector(cfg: &Configuration) -> std::io::Resu
             cron_triggers::check_cron_triggers(&cfg),
             event_triggers::check_event_triggers(&cfg),
         );
-        tokio::time::sleep(std::time::Duration::from_millis(cfg.collect_interval)).await;
+        for _i in 1..100 { // split up the interval so it stops in a useful amount of time
+            if util::should_stop(rx) {
+                return Ok(());
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(cfg.collect_interval / 100)).await;
+        }
     }
 }

--- a/metrics/src/collectors/scheduled_events.rs
+++ b/metrics/src/collectors/scheduled_events.rs
@@ -60,7 +60,7 @@ fn create_scheduled_event_request() -> SQLRequest {
                     args: RunSQLArgs {
                         cascade: false,
                         read_only: true,
-                        sql: "SELECT COUNT(*) FROM hdb_catalog.hdb_cron_events WHERE status = 'error' or status = 'delivered';".to_string()
+                        sql: "SELECT COUNT(*) FROM hdb_catalog.hdb_scheduled_events WHERE status = 'error' or status = 'delivered';".to_string()
                     }
                 },
             ],

--- a/metrics/src/logreader.rs
+++ b/metrics/src/logreader.rs
@@ -1,0 +1,48 @@
+use std::sync::mpsc;
+use log::{error, info};
+use tokio::{
+    fs::File,
+    io::{AsyncBufReadExt, BufReader},
+};
+use std::io::Result;
+
+use crate::{logprocessor, util};
+
+
+pub async fn read_file(log_file: &String, sleep_time: u64, rx: &mpsc::Receiver<()>) -> Result<()> {
+    loop {
+        if util::should_stop(rx) {
+            return Ok(());
+        }
+        match File::open(log_file).await {
+            Ok(file) => {
+                info!("Hasura log file {} open, will follow the log", log_file);
+                process_file(file, sleep_time, rx).await?;
+            }
+            Err(e) => {
+                error!("File {} could not be opened ({}). Will wait a little and then try again...", log_file, e);
+                tokio::time::sleep(std::time::Duration::from_millis(sleep_time)).await;
+            }
+        }
+    }
+}
+
+async fn process_file(file: File, sleep_time: u64, rx: &mpsc::Receiver<()>) -> Result<()> {
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+
+    loop {
+        if util::should_stop(rx) {
+            return Ok(());
+        }
+
+        if let Some(line) = lines.next_line().await? {
+            logprocessor::log_processor(&line).await;
+        } else {
+            // check for file changes every sleep time ms.
+            // This can be quite high, because usually one has a sample rate
+            // for scraping the prometheus metrics of a couple of seconds
+            tokio::time::sleep(std::time::Duration::from_millis(sleep_time)).await;
+        }
+    }
+}

--- a/metrics/src/logreader.rs
+++ b/metrics/src/logreader.rs
@@ -1,48 +1,93 @@
 use std::sync::mpsc;
-use log::{error, info};
+use std::sync::mpsc::{RecvTimeoutError,TryRecvError};
+use log::{error, info, warn};
 use tokio::{
     fs::File,
     io::{AsyncBufReadExt, BufReader},
 };
 use std::io::Result;
+use std::time::Duration;
+use notify::{Watcher, watcher, RecursiveMode, DebouncedEvent};
 
-use crate::{logprocessor, util};
+
+use crate::{logprocessor};
 
 
-pub async fn read_file(log_file: &String, sleep_time: u64, rx: &mpsc::Receiver<()>) -> Result<()> {
+pub async fn read_file(log_file: &String, sleep_time: u64, termination_rx: &mpsc::Receiver<()>) -> Result<()> {
     loop {
-        if util::should_stop(rx) {
-            return Ok(());
-        }
         match File::open(log_file).await {
             Ok(file) => {
                 info!("Hasura log file {} open, will follow the log", log_file);
-                process_file(file, sleep_time, rx).await?;
+                match process_file(log_file, file, sleep_time, termination_rx).await {
+                    Ok(true) => (),
+                    Ok(false) => return Ok(()),
+                    Err(e) => {
+                        warn!("Error reading logfile: {}", e);
+                        ()
+                    }
+                };
+                info!("Need to reopen hasura log file {}", log_file);
             }
             Err(e) => {
                 error!("File {} could not be opened ({}). Will wait a little and then try again...", log_file, e);
-                tokio::time::sleep(std::time::Duration::from_millis(sleep_time)).await;
+                match termination_rx.recv_timeout(std::time::Duration::from_millis(sleep_time)) {
+                    Ok(_) | Err(RecvTimeoutError::Disconnected) => return Ok(()),
+                    Err(RecvTimeoutError::Timeout) => () //continue
+                }
             }
         }
     }
 }
 
-async fn process_file(file: File, sleep_time: u64, rx: &mpsc::Receiver<()>) -> Result<()> {
+async fn process_file(file_name: &String, file: File, sleep_time: u64, termination_rx: &mpsc::Receiver<()>) -> Result<bool> {
+    let (watch_sender, watch_receiver) = mpsc::channel();
+    let mut watcher = watcher(watch_sender, Duration::from_secs(1)).unwrap();
+    watcher.watch(file_name, RecursiveMode::NonRecursive).unwrap();
+
     let reader = BufReader::new(file);
     let mut lines = reader.lines();
 
     loop {
-        if util::should_stop(rx) {
-            return Ok(());
+        match watch_receiver.recv_timeout(Duration::from_millis(sleep_time)) {
+            Ok(DebouncedEvent::Write(_)) => (), //something was written to the file, read it
+            Ok(DebouncedEvent::Remove(_)) => {
+                info!("hasura logfile was removed");
+                return Ok(true);
+            },
+            Ok(DebouncedEvent::Rename(_, _)) => {
+                info!("hasura logfile was renamed");
+                return Ok(true);
+            },
+            Ok(DebouncedEvent::Chmod(_)) => { //happens when moving another file to it
+                info!("hasura logfile was chmod'ed");
+                return Ok(true);
+            },
+            Ok(DebouncedEvent::Rescan) => {
+                info!("hasura logfile needs rescan");
+                return Ok(true);
+            },
+            Ok(DebouncedEvent::Error(e, _)) => {
+                return Err(std::io::Error::new(std::io::ErrorKind::Other, format!("Watching error {}", e)));
+            },
+            Ok(_) => (),
+            Err(RecvTimeoutError::Disconnected) => return Ok(true),
+            Err(RecvTimeoutError::Timeout) => ()
         }
 
-        if let Some(line) = lines.next_line().await? {
-            logprocessor::log_processor(&line).await;
-        } else {
-            // check for file changes every sleep time ms.
-            // This can be quite high, because usually one has a sample rate
-            // for scraping the prometheus metrics of a couple of seconds
-            tokio::time::sleep(std::time::Duration::from_millis(sleep_time)).await;
+        // read data as long as there's new data available
+        loop {
+            match termination_rx.try_recv() {
+                Ok(_) | Err(TryRecvError::Disconnected) => {
+                    return Ok(false)
+                },
+                Err(TryRecvError::Empty) => () //continue
+            }
+
+            if let Some(line) = lines.next_line().await? {
+                logprocessor::log_processor(&line).await;
+            } else {
+                break;
+            }
         }
     }
 }

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -77,7 +77,7 @@ impl Default for Configuration {
                 Arg::new("sleep")
                     .long("sleep")
                     .env("SLEEP_TIME")
-                    .default_value("5000")
+                    .default_value("1000")
                     .takes_value(true),
             )
             .arg(

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -85,6 +85,7 @@ impl Default for Configuration {
                 Arg::new("logfile")
                     .long("logfile")
                     .env("LOG_FILE")
+                    .required(true)
                     .takes_value(true),
             )
             .arg(
@@ -112,6 +113,7 @@ impl Default for Configuration {
                 Arg::new("hasura-admin-secret")
                     .long("hasura-admin-secret")
                     .env("HASURA_GRAPHQL_ADMIN_SECRET")
+                    .required(true)
                     .takes_value(true),
             )
             .get_matches();

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -81,9 +81,9 @@ impl Default for Configuration {
                     .takes_value(true),
             )
             .arg(
-                Arg::new("collect-intervall")
-                    .long("collect-intervall")
-                    .env("COLLECT_INTERVALL")
+                Arg::new("collect-interval")
+                    .long("collect-interval")
+                    .env("COLLECT_INTERVAL")
                     .default_value("15000")
                     .takes_value(true),
             )

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -21,7 +21,7 @@ lazy_static! {
     .unwrap();
 }
 
-async fn read_fille(cfg: &Configuration) -> std::io::Result<()> {
+async fn read_file(cfg: &Configuration) -> std::io::Result<()> {
     let input = File::open(&cfg.log_file).await?;
     let reader = BufReader::new(input);
     let mut lines = reader.lines();
@@ -140,7 +140,7 @@ async fn main() {
 
     let res = tokio::try_join!(
         webserver(&config),
-        read_fille(&config),
+        read_file(&config),
         collectors::run_metadata_collector(&config)
     );
 

--- a/metrics/src/util.rs
+++ b/metrics/src/util.rs
@@ -1,0 +1,8 @@
+use std::sync::mpsc::{Receiver, TryRecvError};
+
+pub fn should_stop(rx: &Receiver<()>) -> bool {
+    match rx.try_recv() {
+        Ok(_) | Err(TryRecvError::Disconnected) => true,
+        Err(TryRecvError::Empty) => false
+    }
+}

--- a/metrics/src/util.rs
+++ b/metrics/src/util.rs
@@ -1,8 +1,0 @@
-use std::sync::mpsc::{Receiver, TryRecvError};
-
-pub fn should_stop(rx: &Receiver<()>) -> bool {
-    match rx.try_recv() {
-        Ok(_) | Err(TryRecvError::Disconnected) => true,
-        Err(TryRecvError::Empty) => false
-    }
-}


### PR DESCRIPTION
This PR does the following:

* allow the process to terminate after ctrl+c (kill) is received. This should help termination time in k8s env
* useful error message instead of panic when the user forgets to specify the required envs (see #7)
* if the log file does not exist yet: wait for it without crashing. This helps when hasura takes longer to start than the adapter (which is usually the case)
* if the log file changes (is deleted, renamed etc.): reopen and watch the new file. Helps when hasura is killed and creates a new named pipe file (using rm & mkfifo).
* fix a few typos in the code

Thanks for your great work, much appreciated!