### PR TITLE
Constant labels and bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,77 @@ Cargo.lock
 # Support for Project snippet scope
 
 # End of https://www.toptal.com/developers/gitignore/api/rust,linux,visualstudiocode
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+*.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser

--- a/metrics/Cargo.lock
+++ b/metrics/Cargo.lock
@@ -928,7 +928,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "metrics"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "actix-web",
  "clap",
@@ -937,6 +937,7 @@ dependencies = [
  "log",
  "notify",
  "prometheus",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -1300,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1311,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -22,3 +22,4 @@ serde_json = "1"
 clap = { version = "3", features = ["env", "cargo", "derive"] }
 notify = "4.0.17"
 snafu = "0.7.1"
+regex = "1.6"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "A prometheus metric generator for Hasura based on the log stream"
 license = "MIT OR Apache-2.0"

--- a/metrics/src/collectors/cron_triggers.rs
+++ b/metrics/src/collectors/cron_triggers.rs
@@ -52,7 +52,7 @@ pub(crate) async fn check_cron_triggers(cfg: &Configuration, metric_obj: &Teleme
     match sql_result {
         Ok(v) => {
             if v.status() == reqwest::StatusCode::OK {
-                let response = v.json::<std::vec::Vec<SQLResult>>().await;
+                let response = v.json::<Vec<SQLResult>>().await;
                 match response {
                     Ok(v) => {
                         if let Some(failed) = v.get(0) {

--- a/metrics/src/collectors/event_triggers.rs
+++ b/metrics/src/collectors/event_triggers.rs
@@ -51,7 +51,7 @@ pub(crate) async fn check_event_triggers(cfg: &Configuration, metric_obj: &Telem
     match sql_result {
         Ok(v) => {
             if v.status() == reqwest::StatusCode::OK {
-                let response = v.json::<std::vec::Vec<SQLResult>>().await;
+                let response = v.json::<Vec<SQLResult>>().await;
                 match response {
                     Ok(v) => {
                         if let Some(failed) = v.get(0) {

--- a/metrics/src/collectors/mod.rs
+++ b/metrics/src/collectors/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::mpsc;
 use std::sync::mpsc::RecvTimeoutError;
-use crate::{Configuration};
+use crate::{Configuration, Telemetry};
 
 mod sql;
 mod health;
@@ -9,14 +9,14 @@ mod scheduled_events;
 mod cron_triggers;
 mod event_triggers;
 
-pub(crate) async fn run_metadata_collector(cfg: &Configuration, termination_rx: &mpsc::Receiver<()>) -> std::io::Result<()> {
+pub(crate) async fn run_metadata_collector(cfg: &Configuration, metric_obj: &Telemetry, termination_rx: &mpsc::Receiver<()>) -> std::io::Result<()> {
     loop {
         tokio::join!(
-            health::check_health(cfg),
-            metadata::check_metadata(cfg),
-            scheduled_events::check_scheduled_events(&cfg),
-            cron_triggers::check_cron_triggers(&cfg),
-            event_triggers::check_event_triggers(&cfg),
+            health::check_health(cfg,metric_obj),
+            metadata::check_metadata(cfg,metric_obj),
+            scheduled_events::check_scheduled_events(&cfg,metric_obj),
+            cron_triggers::check_cron_triggers(&cfg,metric_obj),
+            event_triggers::check_event_triggers(&cfg,metric_obj),
         );
 
         match termination_rx.recv_timeout(std::time::Duration::from_millis(cfg.collect_interval)) {

--- a/metrics/src/collectors/scheduled_events.rs
+++ b/metrics/src/collectors/scheduled_events.rs
@@ -51,7 +51,7 @@ pub(crate) async fn check_scheduled_events(cfg: &Configuration,metric_obj: &Tele
     match sql_result {
         Ok(v) => {
             if v.status() == reqwest::StatusCode::OK {
-                let response = v.json::<std::vec::Vec<SQLResult>>().await;
+                let response = v.json::<Vec<SQLResult>>().await;
                 match response {
                     Ok(v) => {
                         if let Some(Some((count, _))) = v.get(0).map(get_sql_result_value) {

--- a/metrics/src/collectors/scheduled_events.rs
+++ b/metrics/src/collectors/scheduled_events.rs
@@ -1,31 +1,6 @@
 use super::sql::*;
-use crate::{Configuration, ERRORS_TOTAL};
-use lazy_static::lazy_static;
+use crate::{Configuration, Telemetry};
 use log::{warn, info};
-use prometheus::{register_int_gauge, IntGauge};
-
-lazy_static! {
-    static ref SCHEDULED_EVENTS_PENDING: IntGauge = register_int_gauge!(
-        "hasura_pending_one_off_events",
-        "number of pending hasura one off scheduled events"
-    )
-    .unwrap();
-    static ref SCHEDULED_EVENTS_PROCESSED: IntGauge = register_int_gauge!(
-        "hasura_processed_one_off_events",
-        "number of processed hasura one off scheduled events"
-    )
-    .unwrap();
-    static ref SCHEDULED_EVENTS_SUCCESSFUL: IntGauge = register_int_gauge!(
-        "hasura_successful_one_off_events",
-        "number of successful hasura one off scheduled events"
-    )
-    .unwrap();
-    static ref SCHEDULED_EVENTS_FAILED: IntGauge = register_int_gauge!(
-        "hasura_failed_one_off_events",
-        "number of failed hasura one off scheduled events"
-    )
-    .unwrap();
-}
 
 fn create_scheduled_event_request() -> SQLRequest {
     SQLRequest {
@@ -67,7 +42,7 @@ fn create_scheduled_event_request() -> SQLRequest {
         }
 }
 
-pub(crate) async fn check_scheduled_events(cfg: &Configuration) {
+pub(crate) async fn check_scheduled_events(cfg: &Configuration,metric_obj: &Telemetry) {
     if cfg.disabled_collectors.contains(&crate::Collectors::ScheduledEvents) {
         info!("Not collecting scheduled event.");
         return;
@@ -80,16 +55,16 @@ pub(crate) async fn check_scheduled_events(cfg: &Configuration) {
                 match response {
                     Ok(v) => {
                         if let Some(Some((count, _))) = v.get(0).map(get_sql_result_value) {
-                            SCHEDULED_EVENTS_FAILED.set(count);
+                            metric_obj.SCHEDULED_EVENTS_FAILED.set(count);
                         }
                         if let Some(Some((count, _))) = v.get(1).map(get_sql_result_value) {
-                            SCHEDULED_EVENTS_SUCCESSFUL.set(count);
+                            metric_obj.SCHEDULED_EVENTS_SUCCESSFUL.set(count);
                         }
                         if let Some(Some((count, _))) = v.get(2).map(get_sql_result_value) {
-                            SCHEDULED_EVENTS_PENDING.set(count);
+                            metric_obj.SCHEDULED_EVENTS_PENDING.set(count);
                         }
                         if let Some(Some((count, _))) = v.get(3).map(get_sql_result_value) {
-                            SCHEDULED_EVENTS_PROCESSED.set(count);
+                            metric_obj.SCHEDULED_EVENTS_PROCESSED.set(count);
                         }
                     }
                     Err(e) => {
@@ -97,7 +72,7 @@ pub(crate) async fn check_scheduled_events(cfg: &Configuration) {
                             "Failed to collect scheduled event check invalid response format: {}",
                             e
                         );
-                        ERRORS_TOTAL.with_label_values(&["scheduled"]).inc();
+                        metric_obj.ERRORS_TOTAL.with_label_values(&["scheduled"]).inc();
                     }
                 }
             } else {
@@ -105,11 +80,11 @@ pub(crate) async fn check_scheduled_events(cfg: &Configuration) {
                     "Failed to collect scheduled event check invalid status code: {}",
                     v.status()
                 );
-                ERRORS_TOTAL.with_label_values(&["scheduled"]).inc();
+                metric_obj.ERRORS_TOTAL.with_label_values(&["scheduled"]).inc();
             }
         }
         Err(e) => {
-            ERRORS_TOTAL.with_label_values(&["scheduled"]).inc();
+            metric_obj.ERRORS_TOTAL.with_label_values(&["scheduled"]).inc();
             warn!("Failed to collect scheduled event check {}", e);
         }
     };

--- a/metrics/src/logreader.rs
+++ b/metrics/src/logreader.rs
@@ -30,7 +30,7 @@ pub async fn read_file(log_file: &String, metric_obj: &Telemetry, sleep_time: u6
             }
             Err(e) => {
                 error!("File {} could not be opened ({}). Will wait a little and then try again...", log_file, e);
-                match termination_rx.recv_timeout(std::time::Duration::from_millis(sleep_time)) {
+                match termination_rx.recv_timeout(Duration::from_millis(sleep_time)) {
                     Ok(_) | Err(RecvTimeoutError::Disconnected) => return Ok(()),
                     Err(RecvTimeoutError::Timeout) => () //continue
                 }

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -108,6 +108,9 @@ pub(crate) struct Configuration {
 
     #[clap(name ="common-labels", short = 'l', long = "common-labels", env = "COMMON_LABELS", value_parser = MapValueParser::new())]
     common_labels: HashMap<String,String>,
+
+    #[clap(name ="histogram-buckets", long = "histogram-buckets", env = "HISTOGRAM_BUCKETS", value_parser, value_delimiter(';'))]
+    histogram_buckets: Vec<f64>,
 }
 
 async fn signal_handler_ctrl_c(tx: mpsc::Sender<()>) -> std::io::Result<()> {
@@ -151,7 +154,7 @@ async fn main() {
 
     let terminate_rx = signal_handler();
 
-    let metric_obj: Telemetry = Telemetry::new(config.common_labels.clone());
+    let metric_obj: Telemetry = Telemetry::new(config.common_labels.clone(),config.histogram_buckets.clone());
 
     let res = tokio::try_join!(
         webserver(&config),

--- a/metrics/src/telemetry.rs
+++ b/metrics/src/telemetry.rs
@@ -1,0 +1,287 @@
+use std::collections::HashMap;
+use prometheus::{HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts};
+use prometheus::{register_int_counter_vec, register_int_counter, register_int_gauge, register_int_gauge_vec, register_histogram_vec};
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug)]
+pub struct Telemetry {
+    pub ERRORS_TOTAL: IntCounterVec,
+
+    pub CRON_TRIGGER_PENDING: IntGaugeVec,
+    pub CRON_TRIGGER_PROCESSED: IntGaugeVec,
+    pub CRON_TRIGGER_SUCCESSFUL: IntGaugeVec,
+    pub CRON_TRIGGER_FAILED: IntGaugeVec,
+
+    pub EVENT_TRIGGER_PENDING: IntGaugeVec,
+    pub EVENT_TRIGGER_PROCESSED: IntGaugeVec,
+    pub EVENT_TRIGGER_SUCCESSFUL: IntGaugeVec,
+    pub EVENT_TRIGGER_FAILED: IntGaugeVec,
+
+    pub HEALTH_CHECK: IntGauge,
+
+    pub METADATA_CONSISTENCY: IntGauge,
+    pub METADATA_VERSION: IntGaugeVec,
+
+    pub SCHEDULED_EVENTS_PENDING: IntGauge,
+    pub SCHEDULED_EVENTS_PROCESSED: IntGauge,
+    pub SCHEDULED_EVENTS_SUCCESSFUL: IntGauge,
+    pub SCHEDULED_EVENTS_FAILED: IntGauge,
+
+    pub ACTIVE_WEBSOCKET: IntGauge,
+    pub ACTIVE_WEBSOCKET_OPERATIONS: IntGauge,
+    pub WEBSOCKET_OPERATIONS: IntCounterVec,
+
+    pub LOG_LINES_COUNTER_TOTAL: IntCounter,
+    pub LOG_LINES_COUNTER: IntCounterVec,
+
+    pub REQUEST_COUNTER: IntCounterVec,
+    pub REQUEST_QUERY_COUNTER: IntCounterVec,
+    pub QUERY_EXECUTION_TIMES: HistogramVec,
+
+}
+
+impl Telemetry {
+    pub fn new(common_labels: HashMap<String, String>) -> Telemetry {
+
+        let errors_total_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_errors_total"),
+            help : String::from("The total number of errors per collector"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+
+
+        let cron_trigger_pending_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_pending_cron_triggers"),
+            help : String::from("Number of pending hasura cron triggers"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let cron_trigger_processed_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_processed_cron_triggers"),
+            help : String::from("Number of processed hasura cron triggers"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let cron_trigger_successful_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_successful_cron_triggers"),
+            help : String::from("Number of successfully processed hasura cron triggers"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let cron_trigger_failed_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_failed_cron_triggers"),
+            help : String::from("Number of failed hasura cron triggers"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+
+
+        let event_trigger_pending_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_pending_event_triggers"),
+            help : String::from("Number of pending hasura event triggers"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let event_trigger_processed_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_processed_event_triggers"),
+            help : String::from("Number of processed hasura event triggers"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let event_trigger_successful_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_successful_event_triggers"),
+            help : String::from("Number of successfully processed hasura event triggers"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let event_trigger_failed_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_failed_event_triggers"),
+            help : String::from("Number of failed hasura event triggers"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+
+
+        let health_check_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_healthy"),
+            help : String::from("If 1, Hasura GraphQl server is healthy, 0 otherwise"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+
+
+        let metadata_consistency_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_metadata_consistency_status"),
+            help : String::from("If 1, metadata is consistent, 0 otherwise"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let metadata_version_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_metadata_version"),
+            help : String::from("If 1, version is active, 0 otherwise"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+
+
+        let scheduled_events_pending_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_pending_one_off_events"),
+            help : String::from("Number of pending Hasura one off scheduled events"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let scheduled_events_processed_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_processed_one_off_events"),
+            help : String::from("Number of processed Hasura one off scheduled events"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let scheduled_events_successful_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_successful_one_off_events"),
+            help : String::from("Number of successful Hasura one off scheduled events"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let scheduled_events_failed_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_failed_one_off_events"),
+            help : String::from("Number of failed Hasura one off scheduled events"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+
+
+        let active_websockets_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_websockets_active"),
+            help : String::from("Number of Hasura web socket connectios"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let active_websockets_operations_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_websockets_operations_active"),
+            help : String::from("Number of Hasura web socket operations like subscriptions"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let websockets_operations_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_websockets_operations"),
+            help : String::from("Counts websocket operation by operation name and error code. On success, error is '', otherwise it's the error code. Unnnamed operations are ''"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+
+
+        let log_lines_counter_total_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_log_lines_counter_total"),
+            help : String::from("Total number of log lines processed"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let log_lines_counter_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_log_lines_counter"),
+            help : String::from("Number of log lines processed"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+
+
+        let request_counter_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_request_counter"),
+            help : String::from("Number of http requests. It provides status the http status code and url the path that was called."),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+        let request_query_counter_opts = Opts {
+            namespace: String::from(""),
+            subsystem: String::from(""),
+            name : String::from("hasura_request_query_counter"),
+            help : String::from("Number of query requests. On success, error is '', otherwise it's the error code. Unnnamed operations are ''"),
+            const_labels : common_labels.clone(),
+            variable_labels : vec![]
+        };
+
+
+        Telemetry {
+            ERRORS_TOTAL : register_int_counter_vec!(errors_total_opts,&["collector"]).unwrap(),
+
+            CRON_TRIGGER_PENDING: register_int_gauge_vec!(cron_trigger_pending_opts,&["trigger_name"]).unwrap(),
+            CRON_TRIGGER_PROCESSED: register_int_gauge_vec!(cron_trigger_processed_opts,&["trigger_name"]).unwrap(),
+            CRON_TRIGGER_SUCCESSFUL: register_int_gauge_vec!(cron_trigger_successful_opts,&["trigger_name"]).unwrap(),
+            CRON_TRIGGER_FAILED: register_int_gauge_vec!(cron_trigger_failed_opts,&["trigger_name"]).unwrap(),
+
+            EVENT_TRIGGER_PENDING: register_int_gauge_vec!(event_trigger_pending_opts,&["trigger_name"]).unwrap(),
+            EVENT_TRIGGER_PROCESSED: register_int_gauge_vec!(event_trigger_processed_opts,&["trigger_name"]).unwrap(),
+            EVENT_TRIGGER_SUCCESSFUL: register_int_gauge_vec!(event_trigger_successful_opts,&["trigger_name"]).unwrap(),
+            EVENT_TRIGGER_FAILED: register_int_gauge_vec!(event_trigger_failed_opts,&["trigger_name"]).unwrap(),
+
+            HEALTH_CHECK: register_int_gauge!(health_check_opts).unwrap(),
+
+            METADATA_CONSISTENCY: register_int_gauge!(metadata_consistency_opts).unwrap(),
+            METADATA_VERSION: register_int_gauge_vec!(metadata_version_opts,&["hasura_version"]).unwrap(),
+
+            SCHEDULED_EVENTS_PENDING: register_int_gauge!(scheduled_events_pending_opts).unwrap(),
+            SCHEDULED_EVENTS_PROCESSED: register_int_gauge!(scheduled_events_processed_opts).unwrap(),
+            SCHEDULED_EVENTS_SUCCESSFUL: register_int_gauge!(scheduled_events_successful_opts).unwrap(),
+            SCHEDULED_EVENTS_FAILED: register_int_gauge!(scheduled_events_failed_opts).unwrap(),
+
+            ACTIVE_WEBSOCKET: register_int_gauge!(active_websockets_opts).unwrap(),
+            ACTIVE_WEBSOCKET_OPERATIONS: register_int_gauge!(active_websockets_operations_opts).unwrap(),
+            WEBSOCKET_OPERATIONS: register_int_counter_vec!(websockets_operations_opts,&["operation", "error"]).unwrap(),
+
+            LOG_LINES_COUNTER_TOTAL: register_int_counter!(log_lines_counter_total_opts).unwrap(),
+            LOG_LINES_COUNTER: register_int_counter_vec!(log_lines_counter_opts,&["logtype"]).unwrap(),
+
+            REQUEST_COUNTER: register_int_counter_vec!(request_counter_opts,&["url", "status"]).unwrap(),
+            REQUEST_QUERY_COUNTER: register_int_counter_vec!(request_query_counter_opts,&["operation", "error"]).unwrap(),
+            QUERY_EXECUTION_TIMES: register_histogram_vec!(
+                String::from("hasura_query_execution_seconds"),
+                String::from("Query execution time. On success, error is '', otherwise it's the error code. Unnnamed operations are ''"),
+                &["operation", "error"]).unwrap()
+        }
+
+    }
+}


### PR DESCRIPTION
This PR enables the user to provide a set of specific constant labels to the metrics exporter as well as the buckets used in the "Query execution histogram". Closes #20.

Those values can be provided either by command line arguments or by environment values:

A prometheus metric generator for Hasura based on the log stream

`docker run -it --rm hasura-metric-adapter:dev /metrics --help`

```
USAGE:
    metrics [OPTIONS] --logfile <logfile>

OPTIONS:
[...]
        --histogram-buckets <histogram-buckets>
            [env: HISTOGRAM_BUCKETS=] [default: 0.01;0.1;0.5;1;2;5]

    -l, --common-labels <common-labels>
            [env: COMMON_LABELS=] [default: ]
```

Here is an example of the metric list 

<details>
    <summary>before</summary>
    
`$ curl 192.168.0.93:9091/metrics`

```

# HELP hasura_failed_one_off_events Number of failed Hasura one off scheduled events
# TYPE hasura_failed_one_off_events gauge
hasura_failed_one_off_events 0
# HELP hasura_healthy If 1, Hasura GraphQl server is healthy, 0 otherwise
# TYPE hasura_healthy gauge
hasura_healthy 1
# HELP hasura_log_lines_counter Number of log lines processed
# TYPE hasura_log_lines_counter counter
hasura_log_lines_counter{logtype="http-log"} 269
hasura_log_lines_counter{logtype="metadata"} 42
hasura_log_lines_counter{logtype="query-log"} 100
hasura_log_lines_counter{logtype="schema-sync-thread"} 2
hasura_log_lines_counter{logtype="startup"} 10
hasura_log_lines_counter{logtype="unstructured"} 10
# HELP hasura_log_lines_counter_total Total number of log lines processed
# TYPE hasura_log_lines_counter_total counter
hasura_log_lines_counter_total 433
# HELP hasura_metadata_consistency_status If 1, metadata is consistent, 0 otherwise
# TYPE hasura_metadata_consistency_status gauge
hasura_metadata_consistency_status 0
# HELP hasura_metadata_version If 1, version is active, 0 otherwise
# TYPE hasura_metadata_version gauge
hasura_metadata_version{hasura_version="v2.13.0"} 1
# HELP hasura_pending_one_off_events Number of pending Hasura one off scheduled events
# TYPE hasura_pending_one_off_events gauge
hasura_pending_one_off_events 0
# HELP hasura_processed_one_off_events Number of processed Hasura one off scheduled events
# TYPE hasura_processed_one_off_events gauge
hasura_processed_one_off_events 0
# HELP hasura_query_execution_seconds Query execution time. On success, error is '', otherwise it's the error code. Unnnamed operations are ''
# TYPE hasura_query_execution_seconds histogram
hasura_query_execution_seconds_bucket{error="",operation="",le="0.01"} 7
hasura_query_execution_seconds_bucket{error="",operation="",le="0.1"} 8
hasura_query_execution_seconds_bucket{error="",operation="",le="0.5"} 10
hasura_query_execution_seconds_bucket{error="",operation="",le="1"} 10
hasura_query_execution_seconds_bucket{error="",operation="",le="2"} 10
hasura_query_execution_seconds_bucket{error="",operation="",le="5"} 10
hasura_query_execution_seconds_bucket{error="",operation="",le="+Inf"} 10
hasura_query_execution_seconds_sum{error="",operation=""} 0.398901059
hasura_query_execution_seconds_count{error="",operation=""} 10
hasura_query_execution_seconds_bucket{error="",operation="MyQuery",le="0.01"} 0
hasura_query_execution_seconds_bucket{error="",operation="MyQuery",le="0.1"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery",le="0.5"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery",le="1"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery",le="2"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery",le="5"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery",le="+Inf"} 3
hasura_query_execution_seconds_sum{error="",operation="MyQuery"} 0.041049802999999996
hasura_query_execution_seconds_count{error="",operation="MyQuery"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery2",le="0.01"} 0
hasura_query_execution_seconds_bucket{error="",operation="MyQuery2",le="0.1"} 2
hasura_query_execution_seconds_bucket{error="",operation="MyQuery2",le="0.5"} 2
hasura_query_execution_seconds_bucket{error="",operation="MyQuery2",le="1"} 2
hasura_query_execution_seconds_bucket{error="",operation="MyQuery2",le="2"} 2
hasura_query_execution_seconds_bucket{error="",operation="MyQuery2",le="5"} 2
hasura_query_execution_seconds_bucket{error="",operation="MyQuery2",le="+Inf"} 2
hasura_query_execution_seconds_sum{error="",operation="MyQuery2"} 0.03807261
hasura_query_execution_seconds_count{error="",operation="MyQuery2"} 2
hasura_query_execution_seconds_bucket{error="",operation="MyQuery23",le="0.01"} 0
hasura_query_execution_seconds_bucket{error="",operation="MyQuery23",le="0.1"} 13
hasura_query_execution_seconds_bucket{error="",operation="MyQuery23",le="0.5"} 13
hasura_query_execution_seconds_bucket{error="",operation="MyQuery23",le="1"} 13
hasura_query_execution_seconds_bucket{error="",operation="MyQuery23",le="2"} 13
hasura_query_execution_seconds_bucket{error="",operation="MyQuery23",le="5"} 13
hasura_query_execution_seconds_bucket{error="",operation="MyQuery23",le="+Inf"} 13
hasura_query_execution_seconds_sum{error="",operation="MyQuery23"} 0.292508498
hasura_query_execution_seconds_count{error="",operation="MyQuery23"} 13
hasura_query_execution_seconds_bucket{error="",operation="MyQuery4",le="0.01"} 0
hasura_query_execution_seconds_bucket{error="",operation="MyQuery4",le="0.1"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery4",le="0.5"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery4",le="1"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery4",le="2"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery4",le="5"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery4",le="+Inf"} 3
hasura_query_execution_seconds_sum{error="",operation="MyQuery4"} 0.072880411
hasura_query_execution_seconds_count{error="",operation="MyQuery4"} 3
hasura_query_execution_seconds_bucket{error="",operation="MyQuery54",le="0.01"} 0
hasura_query_execution_seconds_bucket{error="",operation="MyQuery54",le="0.1"} 12
hasura_query_execution_seconds_bucket{error="",operation="MyQuery54",le="0.5"} 12
hasura_query_execution_seconds_bucket{error="",operation="MyQuery54",le="1"} 12
hasura_query_execution_seconds_bucket{error="",operation="MyQuery54",le="2"} 12
hasura_query_execution_seconds_bucket{error="",operation="MyQuery54",le="5"} 12
hasura_query_execution_seconds_bucket{error="",operation="MyQuery54",le="+Inf"} 12
hasura_query_execution_seconds_sum{error="",operation="MyQuery54"} 0.18625691299999994
hasura_query_execution_seconds_count{error="",operation="MyQuery54"} 12
# HELP hasura_request_counter Number of http requests. It provides status the http status code and url the path that was called.
# TYPE hasura_request_counter counter
hasura_request_counter{status="200",url="/healthz"} 49
hasura_request_counter{status="200",url="/v1/graphql"} 40
hasura_request_counter{status="200",url="/v1/metadata"} 75
hasura_request_counter{status="200",url="/v1/query"} 9
hasura_request_counter{status="200",url="/v1/version"} 67
hasura_request_counter{status="200",url="/v1alpha1/config"} 1
hasura_request_counter{status="200",url="/v2/query"} 8
hasura_request_counter{status="400",url="/v1/metadata"} 2
hasura_request_counter{status="400",url="/v2/query"} 8
hasura_request_counter{status="401",url="/v1alpha1/config"} 9
hasura_request_counter{status="409",url="/v1/metadata"} 1
# HELP hasura_request_query_counter Number of query requests. On success, error is '', otherwise it's the error code. Unnnamed operations are ''
# TYPE hasura_request_query_counter counter
hasura_request_query_counter{error="",operation=""} 10
hasura_request_query_counter{error="",operation="MyQuery"} 3
hasura_request_query_counter{error="",operation="MyQuery2"} 2
hasura_request_query_counter{error="",operation="MyQuery23"} 13
hasura_request_query_counter{error="",operation="MyQuery4"} 3
hasura_request_query_counter{error="",operation="MyQuery54"} 12
hasura_request_query_counter{error="unexpected",operation=""} 8
hasura_request_query_counter{error="validation-failed",operation="MyQuery4"} 1
# HELP hasura_successful_one_off_events Number of successful Hasura one off scheduled events
# TYPE hasura_successful_one_off_events gauge
hasura_successful_one_off_events 0
# HELP hasura_websockets_active Number of Hasura web socket connectios
# TYPE hasura_websockets_active gauge
hasura_websockets_active 0
# HELP hasura_websockets_operations_active Number of Hasura web socket operations like subscriptions
# TYPE hasura_websockets_operations_active gauge
hasura_websockets_operations_active 0
```

</details>

<details>
    <summary>and after the update</summary>


`$ curl 192.168.0.93:9091/metrics`

```
# HELP hasura_failed_one_off_events Number of failed Hasura one off scheduled events
# TYPE hasura_failed_one_off_events gauge
hasura_failed_one_off_events{env="des"} 0
# HELP hasura_healthy If 1, Hasura GraphQl server is healthy, 0 otherwise
# TYPE hasura_healthy gauge
hasura_healthy{env="des"} 1
# HELP hasura_log_lines_counter Number of log lines processed
# TYPE hasura_log_lines_counter counter
hasura_log_lines_counter{env="des",logtype="http-log"} 212
hasura_log_lines_counter{env="des",logtype="metadata"} 30
hasura_log_lines_counter{env="des",logtype="query-log"} 58
hasura_log_lines_counter{env="des",logtype="schema-sync-thread"} 2
hasura_log_lines_counter{env="des",logtype="startup"} 10
hasura_log_lines_counter{env="des",logtype="unstructured"} 10
# HELP hasura_log_lines_counter_total Total number of log lines processed
# TYPE hasura_log_lines_counter_total counter
hasura_log_lines_counter_total{env="des"} 322
# HELP hasura_metadata_consistency_status If 1, metadata is consistent, 0 otherwise
# TYPE hasura_metadata_consistency_status gauge
hasura_metadata_consistency_status{env="des"} 0
# HELP hasura_metadata_version If 1, version is active, 0 otherwise
# TYPE hasura_metadata_version gauge
hasura_metadata_version{env="des",hasura_version="v2.13.0"} 1
# HELP hasura_pending_one_off_events Number of pending Hasura one off scheduled events
# TYPE hasura_pending_one_off_events gauge
hasura_pending_one_off_events{env="des"} 0
# HELP hasura_processed_one_off_events Number of processed Hasura one off scheduled events
# TYPE hasura_processed_one_off_events gauge
hasura_processed_one_off_events{env="des"} 0
# HELP hasura_query_execution_seconds Query execution time. On success, error is '', otherwise it's the error code. Unnnamed operations are ''
# TYPE hasura_query_execution_seconds histogram
hasura_query_execution_seconds_bucket{env="des",error="",operation="",le="0.1"} 8
hasura_query_execution_seconds_bucket{env="des",error="",operation="",le="0.5"} 10
hasura_query_execution_seconds_bucket{env="des",error="",operation="",le="1"} 10
hasura_query_execution_seconds_bucket{env="des",error="",operation="",le="2"} 10
hasura_query_execution_seconds_bucket{env="des",error="",operation="",le="3"} 10
hasura_query_execution_seconds_bucket{env="des",error="",operation="",le="+Inf"} 10
hasura_query_execution_seconds_sum{env="des",error="",operation=""} 0.398901059
hasura_query_execution_seconds_count{env="des",error="",operation=""} 10
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery",le="0.1"} 3
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery",le="0.5"} 3
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery",le="1"} 3
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery",le="2"} 3
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery",le="3"} 3
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery",le="+Inf"} 3
hasura_query_execution_seconds_sum{env="des",error="",operation="MyQuery"} 0.041049802999999996
hasura_query_execution_seconds_count{env="des",error="",operation="MyQuery"} 3
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery2",le="0.1"} 2
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery2",le="0.5"} 2
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery2",le="1"} 2
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery2",le="2"} 2
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery2",le="3"} 2
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery2",le="+Inf"} 2
hasura_query_execution_seconds_sum{env="des",error="",operation="MyQuery2"} 0.03807261
hasura_query_execution_seconds_count{env="des",error="",operation="MyQuery2"} 2
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery23",le="0.1"} 11
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery23",le="0.5"} 11
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery23",le="1"} 11
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery23",le="2"} 11
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery23",le="3"} 11
hasura_query_execution_seconds_bucket{env="des",error="",operation="MyQuery23",le="+Inf"} 11
hasura_query_execution_seconds_sum{env="des",error="",operation="MyQuery23"} 0.243473727
hasura_query_execution_seconds_count{env="des",error="",operation="MyQuery23"} 11
# HELP hasura_request_counter Number of http requests. It provides status the http status code and url the path that was called.
# TYPE hasura_request_counter counter
hasura_request_counter{env="des",status="200",url="/healthz"} 37
hasura_request_counter{env="des",status="200",url="/v1/graphql"} 18
hasura_request_counter{env="des",status="200",url="/v1/metadata"} 63
hasura_request_counter{env="des",status="200",url="/v1/query"} 9
hasura_request_counter{env="des",status="200",url="/v1/version"} 56
hasura_request_counter{env="des",status="200",url="/v1alpha1/config"} 1
hasura_request_counter{env="des",status="200",url="/v2/query"} 8
hasura_request_counter{env="des",status="400",url="/v1/metadata"} 2
hasura_request_counter{env="des",status="400",url="/v2/query"} 8
hasura_request_counter{env="des",status="401",url="/v1alpha1/config"} 9
hasura_request_counter{env="des",status="409",url="/v1/metadata"} 1
# HELP hasura_request_query_counter Number of query requests. On success, error is '', otherwise it's the error code. Unnnamed operations are ''
# TYPE hasura_request_query_counter counter
hasura_request_query_counter{env="des",error="",operation=""} 10
hasura_request_query_counter{env="des",error="",operation="MyQuery"} 3
hasura_request_query_counter{env="des",error="",operation="MyQuery2"} 2
hasura_request_query_counter{env="des",error="",operation="MyQuery23"} 11
hasura_request_query_counter{env="des",error="unexpected",operation=""} 8
# HELP hasura_successful_one_off_events Number of successful Hasura one off scheduled events
# TYPE hasura_successful_one_off_events gauge
hasura_successful_one_off_events{env="des"} 0
# HELP hasura_websockets_active Number of Hasura web socket connectios
# TYPE hasura_websockets_active gauge
hasura_websockets_active{env="des"} 0
# HELP hasura_websockets_operations_active Number of Hasura web socket operations like subscriptions
# TYPE hasura_websockets_operations_active gauge
hasura_websockets_operations_active{env="des"} 0
```

</details>


To allow a more convenient way for setting the constant labels, the code was refactored. The global variables used in the lazy-static sections were removed in favor of a new struct that hold all the metrics used in the code.  This struct, called Telemetry, along with its constructor, was moved to a new file. 

On one hand, all the metrics definitions are now in the same place. Therefore, in the event of either new ones being included, or the Prometheus api breaking compatibility, the maintenance of the code is easier now.

On the other hand, the object with the metrics must be passed between functions and the code is now a bit more verbose.

To conclude, with this changes, the modification required to enable user-defined bucket sizes are straightforward: the value is read from the corresponding command line option, passed to the Telemetry's constructor and then, included among the options of the histogram.