### PR TITLE
Build docker image for arm64

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GH_REGISTRY_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v2
         with:
           push: true # Will only build if this is not here
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,30 @@
-FROM rust:1.58 as build
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM rust:1.58 as build
+ARG TARGETARCH
 
 RUN echo "export PATH=/usr/local/cargo/bin:$PATH" >> /etc/profile
-
 WORKDIR /app
+
+COPY ["./build/platform.sh", "./"]
+RUN ./platform.sh
+COPY ["./build/.cargo/config", ".cargo/config"]
+RUN rustup target add $(cat /.platform)
+RUN apt-get update && apt-get install -y $(cat /.compiler)
 
 COPY ["./metrics/Cargo.toml", "./metrics/Cargo.lock", "./"]
 
-RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release
+RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release --target=$(cat /.platform)
 
 COPY ["./metrics/src", "./src"]
 
-RUN touch src/main.rs && cargo build --release
+RUN touch src/main.rs && cargo build --release --target=$(cat /.platform)
+
+RUN mkdir -p /release/$TARGETARCH
+RUN cp ./target/$(cat /.platform)/release/metrics /release/$TARGETARCH/metrics
 
 FROM gcr.io/distroless/cc-debian11
-
-COPY --from=build /app/target/release/metrics /
+ARG TARGETARCH
+COPY --from=build /release/$TARGETARCH/metrics /
 
 CMD ["/metrics"]

--- a/build/.cargo/config
+++ b/build/.cargo/config
@@ -1,0 +1,5 @@
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/build/platform.sh
+++ b/build/platform.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Used in Docker build to set platform dependent variables
+
+case $TARGETARCH in
+
+    "amd64")
+	echo "x86_64-unknown-linux-gnu" > /.platform
+	echo "" > /.compiler 
+	;;
+    "arm64") 
+	echo "aarch64-unknown-linux-gnu" > /.platform
+	echo "gcc-aarch64-linux-gnu" > /.compiler
+	;;
+    "arm")
+	echo "armv7-unknown-linux-gnueabihf" > /.platform
+	echo "gcc-arm-linux-gnueabihf" > /.compiler
+	;;
+esac

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -23,3 +23,4 @@ clap = { version = "3", features = ["env", "cargo", "derive"] }
 notify = "4.0.17"
 snafu = "0.7.1"
 regex = "1.6"
+openssl = { version = "0.10.40", features = ["vendored"] }


### PR DESCRIPTION
Hi Andreas!
I've been looking for a metrics solution for hasura CE, but my target cluster works on arm64 so I spent some time adding cross-compilation capabilities. 
I manage to make this thing build a multi-platform image in my fork: https://github.com/asan/hasura-metric-adapter/actions/runs/3379609670
And check this image in my cluster, everything works like a charm.

I tried to make a minimal amount of changes, but I`m definitely not an expert in compiling rust, so if you have some suggestions I would be glad to listen.