### PR TITLE
Add default value to common-labels to make this argument optional

### DIFF
--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -107,7 +107,7 @@ pub(crate) struct Configuration {
     disabled_collectors: Vec<Collectors>,
 
     #[clap(name ="common-labels", short = 'l', long = "common-labels", env = "COMMON_LABELS", value_parser = MapValueParser::new())]
-    common_labels: HashMap<String,String>,
+    common_labels: Option<HashMap<String,String>>,
 
     #[clap(name ="histogram-buckets", long = "histogram-buckets", env = "HISTOGRAM_BUCKETS", value_parser, value_delimiter(';'))]
     histogram_buckets: Vec<f64>,
@@ -154,7 +154,7 @@ async fn main() {
 
     let terminate_rx = signal_handler();
 
-    let metric_obj: Telemetry = Telemetry::new(config.common_labels.clone(),config.histogram_buckets.clone());
+    let metric_obj: Telemetry = Telemetry::new(config.common_labels.clone().unwrap_or_default(),config.histogram_buckets.clone());
 
     let res = tokio::try_join!(
         webserver(&config),


### PR DESCRIPTION
Make `common-labels` argument optional with default value of empty map.
Should fix #23 