### PR TITLE
Event metrics correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ USAGE:
 OPTIONS:
         --collect-interval <collect-interval>
             [env: COLLECT_INTERVAL=] [default: 15000]
+        
+        --concurrency-limit <concurrency-limit>
+            [env: CONCURRENCY_LIMIT=] [default: 0]
 
         --exclude_collectors <collector>[;collector...]
             [env: EXCLUDE_COLLECTORS=] [possible values: cron-triggers, event-triggers,
@@ -132,7 +135,7 @@ EXCLUDE_COLLECTORS=cron-triggers;event-triggers;scheduled-events
     This is a gauge, that holds a `hasura_version` label, with the hasura version
     and the value of `1` if that version was detected.
 
-The following metrics are the same as in the project (https://github.com/zolamk/hasura-exporter), also the idea on how to access them is based on it. So all credit for these need to go to @zolamk, I just ported them here. (These metrics are disabled if no admin secret is provided.)
+The following metrics are the same as in the project (https://github.com/zolamk/hasura-exporter), also the idea on how to access them is based on it. So all credit for these need to go to @zolamk, I just ported them here. These metrics are disabled if no admin secret is provided. Cron triggers and one off events won't work if the postgres database with the metadata is not accessible as a data source with the 'default' name.
 
 - `hasura_pending_cron_triggers`, `hasura_processed_cron_triggers`, `hasura_successful_cron_triggers`, `hasura_failed_cron_triggers`
 

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -24,3 +24,4 @@ notify = "4.0.17"
 snafu = "0.7.1"
 regex = "1.6"
 openssl = { version = "0.10.40", features = ["vendored"] }
+futures = "0.3.25"

--- a/metrics/src/collectors/cron_triggers.rs
+++ b/metrics/src/collectors/cron_triggers.rs
@@ -1,6 +1,6 @@
 use super::sql::*;
 use crate::{Configuration, Telemetry};
-use log::{warn, info};
+use log::{warn, info, debug};
 
 
 fn create_cron_trigger_request() -> SQLRequest {
@@ -52,6 +52,7 @@ pub(crate) async fn check_cron_triggers(cfg: &Configuration, metric_obj: &Teleme
         info!("Not collecting cron triggers.");
         return;
     }
+    debug!("Running SQL query for cron triggers");
     let sql_result = make_sql_request(&create_cron_trigger_request(), cfg).await;
     match sql_result {
         Ok(v) => {

--- a/metrics/src/collectors/cron_triggers.rs
+++ b/metrics/src/collectors/cron_triggers.rs
@@ -61,47 +61,105 @@ pub(crate) async fn check_cron_triggers(cfg: &Configuration, metric_obj: &Teleme
                 match response {
                     Ok(v) => {
                         if let Some(failed) = v.get(0) {
-                            failed.result.iter().skip(1).for_each(|entry| {
-                                if let Some((value, Some(label))) = get_sql_entry_value(entry) {
-                                    metric_obj.CRON_TRIGGER_FAILED.with_label_values(&[label.as_str()]).set(value);
-                                }
-                            });
+                            if failed.result_type == "TuplesOK" {
+                                failed.result.as_ref().unwrap().iter().skip(1).for_each(|entry| {
+                                    match entry {
+                                        SQLResultItem::IntStr(value,trigger_name) => {
+                                            metric_obj.CRON_TRIGGER_FAILED.with_label_values(&[trigger_name]).set(*value);
+                                        }
+                                        SQLResultItem::StrStr(count,trigger_name) => {
+                                            let value = match count.trim().parse::<i64>() {
+                                                Ok(value) => value,
+                                                _ => 0,
+                                            };
+                                            metric_obj.CRON_TRIGGER_FAILED.with_label_values(&[trigger_name]).set(value);
+                                        }
+                                        default => {
+                                            warn!("Failed to process entry '{:?}', expected two values [ count, trigger_name ]",default);
+                                        }
+                                    }
+                                });
+                            } else {
+                                info!("Result of SQL query for 'failed cron trigger' has failed or is empty: {:?}", failed);
+                            }
                         }
                         if let Some(success) = v.get(1) {
-                            success.result.iter().skip(1).for_each(|entry| {
-                                if let Some((value, Some(label))) = get_sql_entry_value(entry) {
-                                    metric_obj.CRON_TRIGGER_SUCCESSFUL.with_label_values(&[label.as_str()]).set(value);
-                                }
-                            });
+                            if success.result_type == "TuplesOK" {
+                                success.result.as_ref().unwrap().iter().skip(1).for_each(|entry| {
+                                    match entry {
+                                        SQLResultItem::IntStr(value,trigger_name) => {
+                                            metric_obj.CRON_TRIGGER_SUCCESSFUL.with_label_values(&[trigger_name]).set(*value);
+                                        }
+                                        SQLResultItem::StrStr(count,trigger_name) => {
+                                            let value = match count.trim().parse::<i64>() {
+                                                Ok(value) => value,
+                                                _ => 0,
+                                            };
+                                            metric_obj.CRON_TRIGGER_SUCCESSFUL.with_label_values(&[trigger_name]).set(value);
+                                        }
+                                        default => {
+                                            warn!("Failed to process entry '{:?}', expected two values [ count, trigger_name ]",default);
+                                        }
+                                    }
+                                });
+                            } else {
+                                info!("Result of SQL query for 'successful cron trigger' has failed or is empty: {:?}", success);
+                            }
                         }
                         if let Some(pending) = v.get(2) {
-                            pending.result.iter().skip(1).for_each(|entry| {
-                                if let Some((value, Some(label))) = get_sql_entry_value(entry) {
-                                    metric_obj.CRON_TRIGGER_PENDING.with_label_values(&[label.as_str()]).set(value);
-                                }
-                            });
+                            if pending.result_type == "TuplesOK" {
+                                pending.result.as_ref().unwrap().iter().skip(1).for_each(|entry| {
+                                    match entry {
+                                        SQLResultItem::IntStr(value,trigger_name) => {
+                                            metric_obj.CRON_TRIGGER_PENDING.with_label_values(&[trigger_name]).set(*value);
+                                        }
+                                        SQLResultItem::StrStr(count,trigger_name) => {
+                                            let value = match count.trim().parse::<i64>() {
+                                                Ok(value) => value,
+                                                _ => 0,
+                                            };
+                                            metric_obj.CRON_TRIGGER_PENDING.with_label_values(&[trigger_name]).set(value);
+                                        }
+                                        default => {
+                                            warn!("Failed to process entry '{:?}', expected two values [ count, trigger_name ]",default);
+                                        }
+                                    }
+                                });
+                            } else {
+                                info!("Result of SQL query for 'pending cron trigger' has failed or is empty: {:?}", pending);
+                            }
                         }
                         if let Some(processed) = v.get(3) {
-                            processed.result.iter().skip(1).for_each(|entry| {
-                                if let Some((value, Some(label))) = get_sql_entry_value(entry) {
-                                    metric_obj.CRON_TRIGGER_PROCESSED.with_label_values(&[label.as_str()]).set(value);
-                                }
-                            });
+                            if processed.result_type == "TuplesOK" {
+                                processed.result.as_ref().unwrap().iter().skip(1).for_each(|entry| {
+                                    match entry {
+                                        SQLResultItem::IntStr(value,trigger_name) => {
+                                            metric_obj.CRON_TRIGGER_PROCESSED.with_label_values(&[trigger_name]).set(*value);
+                                        }
+                                        SQLResultItem::StrStr(count,trigger_name) => {
+                                            let value = match count.trim().parse::<i64>() {
+                                                Ok(value) => value,
+                                                _ => 0,
+                                            };
+                                            metric_obj.CRON_TRIGGER_PROCESSED.with_label_values(&[trigger_name]).set(value);
+                                        }
+                                        default => {
+                                            warn!("Failed to process entry '{:?}', expected two values [ count, trigger_name ]",default);
+                                        }
+                                    }
+                                });
+                            } else {
+                                info!("Result of SQL query for 'processed cron trigger' has failed or is empty: {:?}", processed);
+                            }
                         }
                     }
                     Err(e) => {
-                        warn!(
-                            "Failed to collect cron triggers check invalid response format: {}",
-                            e
-                        );
+                        warn!( "Failed to collect cron triggers check invalid response format: {}", e );
                         metric_obj.ERRORS_TOTAL.with_label_values(&["cron"]).inc();
                     }
                 }
             } else {
-                warn!(
-                    "Failed to collect cron triggers check invalid status code: {}",
-                    v.status()
-                );
+                warn!( "Failed to collect cron triggers check invalid status code: {}", v.status() );
                 metric_obj.ERRORS_TOTAL.with_label_values(&["cron"]).inc();
             }
         }

--- a/metrics/src/collectors/cron_triggers.rs
+++ b/metrics/src/collectors/cron_triggers.rs
@@ -10,6 +10,7 @@ fn create_cron_trigger_request() -> SQLRequest {
                 RunSQLQuery{
                     request_type: "run_sql".to_string(),
                     args: RunSQLArgs {
+                        source: "default".to_string(),
                         cascade: false,
                         read_only: true,
                         sql: "SELECT COUNT(*), trigger_name FROM hdb_catalog.hdb_cron_events WHERE status = 'error' GROUP BY trigger_name;".to_string()
@@ -18,6 +19,7 @@ fn create_cron_trigger_request() -> SQLRequest {
                 RunSQLQuery{
                     request_type: "run_sql".to_string(),
                     args: RunSQLArgs {
+                        source: "default".to_string(),
                         cascade: false,
                         read_only: true,
                         sql: "SELECT COUNT(*), trigger_name FROM hdb_catalog.hdb_cron_events WHERE status = 'delivered' GROUP BY trigger_name;".to_string()
@@ -26,6 +28,7 @@ fn create_cron_trigger_request() -> SQLRequest {
                 RunSQLQuery{
                     request_type: "run_sql".to_string(),
                     args: RunSQLArgs {
+                        source: "default".to_string(),
                         cascade: false,
                         read_only: true,
                         sql: "SELECT COUNT(*), trigger_name FROM hdb_catalog.hdb_cron_events WHERE status = 'scheduled' GROUP BY trigger_name;".to_string()
@@ -34,6 +37,7 @@ fn create_cron_trigger_request() -> SQLRequest {
                 RunSQLQuery{
                     request_type: "run_sql".to_string(),
                     args: RunSQLArgs {
+                        source: "default".to_string(),
                         cascade: false,
                         read_only: true,
                         sql: "SELECT COUNT(*), trigger_name FROM hdb_catalog.hdb_cron_events WHERE status = 'error' or status = 'delivered' GROUP BY trigger_name;".to_string()

--- a/metrics/src/collectors/event_triggers.rs
+++ b/metrics/src/collectors/event_triggers.rs
@@ -127,14 +127,13 @@ pub(crate) async fn check_event_triggers(cfg: &Configuration, metric_obj: &Telem
 
     debug!("Processing all the databases to look for event triggers");
 
-    const MAX_CONCURRENT_JUMPERS: usize = 100;
     let list_tmp = metadata["metadata"]["sources"].as_array();
 
     match list_tmp {
         Some(list) => {
 
             let stream = stream::iter(list);
-            stream.for_each_concurrent(MAX_CONCURRENT_JUMPERS, |data_source| async move {
+            stream.for_each_concurrent(cfg.concurrency_limit, |data_source| async move {
 
                 debug!("Processing database {} of kind {}",data_source["name"],data_source["kind"]);
                 process_database(data_source.as_object().unwrap(), cfg, metric_obj).await;

--- a/metrics/src/collectors/health.rs
+++ b/metrics/src/collectors/health.rs
@@ -1,13 +1,15 @@
 use crate::{Configuration, Telemetry};
-use log::warn;
+use log::{debug, warn};
 
 pub(crate) async fn check_health(cfg: &Configuration, metric_obj: &Telemetry) {
     let health_check = reqwest::get(format!("{}/healthz", cfg.hasura_addr)).await;
     match health_check {
         Ok(v) => {
             if v.status() == reqwest::StatusCode::OK {
+                debug!("Healthcheck OK");
                 metric_obj.HEALTH_CHECK.set(1);
             } else {
+                debug!("Healthcheck NOK");
                 metric_obj.HEALTH_CHECK.set(0);
             }
         },

--- a/metrics/src/collectors/metadata.rs
+++ b/metrics/src/collectors/metadata.rs
@@ -3,13 +3,14 @@ use std::collections::HashMap;
 use crate::{Configuration, Telemetry};
 use log::warn;
 use serde::{Serialize, Deserialize};
+use serde_json::{json, Map, Value};
 
 #[derive(Serialize)]
 pub struct MetadataCheckRequest {
     #[serde(rename = "type")]
     pub request_type: String,
     #[serde(rename = "args")]
-    pub args: HashMap<String, serde_json::Value>,
+    pub args: HashMap<String, Value>,
 }
 
 impl MetadataCheckRequest {
@@ -25,6 +26,26 @@ impl MetadataCheckRequest {
 pub struct MetadataCheckResponse {
     #[serde(rename = "is_consistent")]
     pub is_consistent: bool
+}
+
+#[derive(Serialize)]
+pub struct MetadataExportRequest {
+    #[serde(rename = "type")]
+    pub request_type: String,
+    #[serde(rename = "version")]
+    pub version: i32,
+    #[serde(rename = "args")]
+    pub args: HashMap<String, Value>,
+}
+
+impl MetadataExportRequest {
+    fn export_metadata() -> Self {
+        MetadataExportRequest {
+            request_type: "export_metadata".to_string(),
+            version: 2,
+            args: HashMap::new(),
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -65,17 +86,19 @@ async fn fetch_version(cfg: &Configuration, metric_obj: &Telemetry) {
     };
 }
 
-async fn fetch_metadata(cfg: &Configuration, metric_obj: &Telemetry) {
+async fn fetch_metadata_consistency(cfg: &Configuration, metric_obj: &Telemetry) -> bool {
+    let mut consistency = false;
     if cfg.disabled_collectors.contains(&crate::Collectors::MetadataInconsistency) {
-        return
+        return consistency;
     }
     let admin_secret = match &cfg.hasura_admin {
         Some(v) => v,
         None => {
             warn!("Metadata should be collected, but admin secret missing!");
-            return;
+            return consistency;
         }
     };
+
     let client = reqwest::Client::new();
     let metadata_check = client
         .post(format!("{}/v1/metadata", cfg.hasura_addr))
@@ -83,6 +106,7 @@ async fn fetch_metadata(cfg: &Configuration, metric_obj: &Telemetry) {
         .header("x-hasura-admin-secret", admin_secret)
         .send()
         .await;
+    
     match metadata_check {
         Ok(v) => {
             if v.status() == reqwest::StatusCode::OK {
@@ -91,6 +115,7 @@ async fn fetch_metadata(cfg: &Configuration, metric_obj: &Telemetry) {
                     Ok(v) => {
                         if v.is_consistent {
                             metric_obj.METADATA_CONSISTENCY.set(1);
+                            consistency = true;
                         } else {
                             metric_obj.METADATA_CONSISTENCY.set(0);
                         }
@@ -110,11 +135,82 @@ async fn fetch_metadata(cfg: &Configuration, metric_obj: &Telemetry) {
             warn!("Failed to collect metadata check {}", e);
         }
     };
+
+    return consistency;
 }
 
-pub(crate) async fn check_metadata(cfg: &Configuration, metric_obj: &Telemetry) {
+
+async fn fetch_metadata(cfg: &Configuration, metric_obj: &Telemetry) -> Map<String, Value> {
+    
+    let mut metadata = json!({}).as_object().unwrap().clone();
+    
+    if cfg.disabled_collectors.contains(&crate::Collectors::EventTriggers) {
+        return metadata;
+    }
+    
+    let admin_secret = match &cfg.hasura_admin {
+        Some(v) => v,
+        None => {
+            warn!("Metadata should be collected, but admin secret missing!");
+            return metadata;
+        }
+    };
+    let client = reqwest::Client::new();
+    let metadata_export = client
+        .post(format!("{}/v1/metadata", cfg.hasura_addr))
+        .json(&MetadataExportRequest::export_metadata())
+        .header("x-hasura-admin-secret", admin_secret)
+        .send()
+        .await;
+
+    match metadata_export {
+        Ok(v) => {
+            if v.status() == reqwest::StatusCode::OK {
+                let response = v.json::<Map<String, Value>>().await;
+                match response {
+                    Ok(v) => {
+                        metadata = v.clone();
+                    },
+                    Err(e) => {
+                        warn!("Failed to fetch metadata. Invalid response format: {}", e);
+                        metric_obj.ERRORS_TOTAL.with_label_values(&["metadata"]).inc();
+                    }
+                }
+            } else {
+                warn!("Failed to collect metadata check invalid status code: {}", v.status());
+                metric_obj.ERRORS_TOTAL.with_label_values(&["metadata"]).inc();
+            }
+        }
+        Err(e) => {
+            metric_obj.ERRORS_TOTAL.with_label_values(&["metadata"]).inc();
+            warn!("Failed to collect metadata check {}", e);
+        }
+    };
+    return metadata;
+}
+
+async fn dummy() {
+    return;
+}
+pub(crate) async fn check_metadata(cfg: &Configuration, metric_obj: &Telemetry) -> Map<String, Value> {
+    let consistent: bool;
+    let metadata;
+
     tokio::join!(
-        fetch_version(cfg,metric_obj),
-        fetch_metadata(cfg,metric_obj)
+        fetch_version(cfg, metric_obj),
+        {
+            consistent = fetch_metadata_consistency(cfg, metric_obj).await;
+
+            if consistent {
+                metadata = fetch_metadata(cfg, metric_obj).await
+            } else {
+                warn!("Failed to collect metadata because it is inconsistent");
+                metric_obj.ERRORS_TOTAL.with_label_values(&["metadata"]).inc();
+                metadata = json!({}).as_object().unwrap().clone()
+            }
+            dummy()
+        }
     );
+
+    return metadata;
 }

--- a/metrics/src/collectors/metadata.rs
+++ b/metrics/src/collectors/metadata.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{Configuration, Telemetry};
-use log::warn;
+use log::{warn,debug};
 use serde::{Serialize, Deserialize};
 use serde_json::{json, Map, Value};
 
@@ -202,6 +202,7 @@ pub(crate) async fn check_metadata(cfg: &Configuration, metric_obj: &Telemetry) 
             consistent = fetch_metadata_consistency(cfg, metric_obj).await;
 
             if consistent {
+                debug!("Metadata is consistent");
                 metadata = fetch_metadata(cfg, metric_obj).await
             } else {
                 warn!("Failed to collect metadata because it is inconsistent");

--- a/metrics/src/collectors/metadata.rs
+++ b/metrics/src/collectors/metadata.rs
@@ -189,17 +189,13 @@ async fn fetch_metadata(cfg: &Configuration, metric_obj: &Telemetry) -> Map<Stri
     return metadata;
 }
 
-async fn dummy() {
-    return;
-}
 pub(crate) async fn check_metadata(cfg: &Configuration, metric_obj: &Telemetry) -> Map<String, Value> {
-    let consistent: bool;
-    let metadata;
+    let mut metadata = json!({}).as_object().unwrap().clone();
 
     tokio::join!(
         fetch_version(cfg, metric_obj),
-        {
-            consistent = fetch_metadata_consistency(cfg, metric_obj).await;
+        async {
+            let consistent = fetch_metadata_consistency(cfg, metric_obj).await;
 
             if consistent {
                 debug!("Metadata is consistent");
@@ -207,9 +203,7 @@ pub(crate) async fn check_metadata(cfg: &Configuration, metric_obj: &Telemetry) 
             } else {
                 warn!("Failed to collect metadata because it is inconsistent");
                 metric_obj.ERRORS_TOTAL.with_label_values(&["metadata"]).inc();
-                metadata = json!({}).as_object().unwrap().clone()
             }
-            dummy()
         }
     );
 

--- a/metrics/src/collectors/mod.rs
+++ b/metrics/src/collectors/mod.rs
@@ -18,9 +18,9 @@ pub(crate) async fn run_metadata_collector(cfg: &Configuration, metric_obj: &Tel
             health::check_health(cfg,metric_obj),
             scheduled_events::check_scheduled_events(&cfg,metric_obj),
             cron_triggers::check_cron_triggers(&cfg,metric_obj),
-            {
-                metadata = metadata::check_metadata(cfg,metric_obj).await;
-                event_triggers::check_event_triggers(&cfg,metric_obj, &metadata)
+            async {
+                let metadata = metadata::check_metadata(cfg,metric_obj).await;
+                event_triggers::check_event_triggers(&cfg,metric_obj, &metadata).await;
             }
         );
 

--- a/metrics/src/collectors/mod.rs
+++ b/metrics/src/collectors/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::mpsc;
 use std::sync::mpsc::RecvTimeoutError;
+use log::debug;
 use crate::{Configuration, Telemetry};
 
 mod sql;
@@ -11,8 +12,7 @@ mod event_triggers;
 
 pub(crate) async fn run_metadata_collector(cfg: &Configuration, metric_obj: &Telemetry, termination_rx: &mpsc::Receiver<()>) -> std::io::Result<()> {
     loop {
-
-        let metadata;
+        debug!("Running metadata collector");
 
         tokio::join!(
             health::check_health(cfg,metric_obj),
@@ -23,8 +23,6 @@ pub(crate) async fn run_metadata_collector(cfg: &Configuration, metric_obj: &Tel
                 event_triggers::check_event_triggers(&cfg,metric_obj, &metadata)
             }
         );
-
-
 
         match termination_rx.recv_timeout(std::time::Duration::from_millis(cfg.collect_interval)) {
             Ok(_) | Err(RecvTimeoutError::Disconnected) => return Ok(()),

--- a/metrics/src/collectors/scheduled_events.rs
+++ b/metrics/src/collectors/scheduled_events.rs
@@ -59,24 +59,170 @@ pub(crate) async fn check_scheduled_events(cfg: &Configuration,metric_obj: &Tele
                 let response = v.json::<Vec<SQLResult>>().await;
                 match response {
                     Ok(v) => {
-                        if let Some(Some((count, _))) = v.get(0).map(get_sql_result_value) {
-                            metric_obj.SCHEDULED_EVENTS_FAILED.set(count);
+                        if let Some(failed) = v.get(0) {
+                            if failed.result_type == "TuplesOK" {
+                                if failed.result.as_ref().unwrap().len() == 1 {
+                                    let entry = &failed.result.as_ref().unwrap()[0];
+                                    match entry {
+                                        SQLResultItem::Str(vect) => {
+                                            let parsed_count;
+                                            if vect.len() == 1 {
+                                                parsed_count = match vect[0].trim().parse::<i64>() {
+                                                    Ok(value) => value,
+                                                    Err(_) => 0,
+                                                };
+                                            } else {
+                                                warn!("Failed to process entry '{:?}', expected one value [ count ]",vect);
+                                                parsed_count = 0;
+                                            }
+                                            metric_obj.SCHEDULED_EVENTS_FAILED.set(parsed_count);
+                                        }
+                                        SQLResultItem::Int(vect) => {
+                                            let count;
+                                            if vect.len() == 1 {
+                                                count = vect[0];
+                                            } else {
+                                                count = 0;
+                                                warn!("Failed to process entry '{:?}', expected one value [ count ]",vect);
+                                            }
+                                            metric_obj.SCHEDULED_EVENTS_FAILED.set(count);
+                                        }
+                                        default => {
+                                            metric_obj.SCHEDULED_EVENTS_FAILED.set(0);
+                                            warn!("Failed to process entry '{:?}', expected one value [ count ]",default);
+                                        }
+                                    }
+                                } else {
+                                    warn!("Failed to process 'failed scheduled triggers' because the sql query response has incorrect format: '{:?}'",failed);
+                                }
+                            } else {
+                                info!("Result of SQL query for 'failed scheduled trigger' has failed or is empty: {:?}", failed);
+                            }
                         }
-                        if let Some(Some((count, _))) = v.get(1).map(get_sql_result_value) {
-                            metric_obj.SCHEDULED_EVENTS_SUCCESSFUL.set(count);
+                        if let Some(success) = v.get(1) {
+                            if success.result_type == "TuplesOK" {
+                                if success.result.as_ref().unwrap().len() == 1 {
+                                    let entry = &success.result.as_ref().unwrap()[0];
+                                    match entry {
+                                        SQLResultItem::Str(vect) => {
+                                            let parsed_count;
+                                            if vect.len() == 1 {
+                                                parsed_count = match vect[0].trim().parse::<i64>() {
+                                                    Ok(value) => value,
+                                                    Err(_) => 0,
+                                                };
+                                            } else {
+                                                warn!("Failed to process entry '{:?}', expected one value [ count ]",vect);
+                                                parsed_count = 0;
+                                            }
+                                            metric_obj.SCHEDULED_EVENTS_SUCCESSFUL.set(parsed_count);
+                                        }
+                                        SQLResultItem::Int(vect) => {
+                                            let count;
+                                            if vect.len() == 1 {
+                                                count = vect[0];
+                                            } else {
+                                                count = 0;
+                                                warn!("Failed to process entry '{:?}', expected one value [ count ]",vect);
+                                            }
+                                            metric_obj.SCHEDULED_EVENTS_SUCCESSFUL.set(count);
+                                        }
+                                        default => {
+                                            metric_obj.SCHEDULED_EVENTS_SUCCESSFUL.set(0);
+                                            warn!("Failed to process entry '{:?}', expected one value [ count ]",default);
+                                        }
+                                    }
+                                } else {
+                                    warn!("Failed to process 'successful scheduled triggers' because the sql query response has incorrect format: '{:?}'",success);
+                                }
+                            } else {
+                                info!("Result of SQL query for 'successful scheduled trigger' has failed or is empty: {:?}", success);
+                            }
                         }
-                        if let Some(Some((count, _))) = v.get(2).map(get_sql_result_value) {
-                            metric_obj.SCHEDULED_EVENTS_PENDING.set(count);
+                        if let Some(pending) = v.get(2) {
+                            if pending.result_type == "TuplesOK" {
+                                if pending.result.as_ref().unwrap().len() == 1 {
+                                    let entry = &pending.result.as_ref().unwrap()[0];
+                                    match entry {
+                                        SQLResultItem::Str(vect) => {
+                                            let parsed_count;
+                                            if vect.len() == 1 {
+                                                parsed_count = match vect[0].trim().parse::<i64>() {
+                                                    Ok(value) => value,
+                                                    Err(_) => 0,
+                                                };
+                                            } else {
+                                                warn!("Failed to process entry '{:?}', expected one value [ count ]",vect);
+                                                parsed_count = 0;
+                                            }
+                                            metric_obj.SCHEDULED_EVENTS_PENDING.set(parsed_count);
+                                        }
+                                        SQLResultItem::Int(vect) => {
+                                            let count;
+                                            if vect.len() == 1 {
+                                                count = vect[0];
+                                            } else {
+                                                count = 0;
+                                                warn!("Failed to process entry '{:?}', expected one value [ count ]",vect);
+                                            }
+                                            metric_obj.SCHEDULED_EVENTS_PENDING.set(count);
+                                        }
+                                        default => {
+                                            metric_obj.SCHEDULED_EVENTS_PENDING.set(0);
+                                            warn!("Failed to process entry '{:?}', expected one value [ count ]",default);
+                                        }
+                                    }
+                                } else {
+                                    warn!("Failed to process 'pending scheduled triggers' because the sql query response has incorrect format: '{:?}'",pending);
+                                }
+                            } else {
+                                info!("Result of SQL query for 'pending scheduled trigger' has failed or is empty: {:?}", pending);
+                            }
                         }
-                        if let Some(Some((count, _))) = v.get(3).map(get_sql_result_value) {
-                            metric_obj.SCHEDULED_EVENTS_PROCESSED.set(count);
+                        if let Some(processed) = v.get(3) {
+                            if processed.result_type == "TuplesOK" {
+                                if processed.result.as_ref().unwrap().len() == 1 {
+                                    let entry = &processed.result.as_ref().unwrap()[0];
+                                    match entry {
+                                        SQLResultItem::Str(vect) => {
+                                            let parsed_count;
+                                            if vect.len() == 1 {
+                                                parsed_count = match vect[0].trim().parse::<i64>() {
+                                                    Ok(value) => value,
+                                                    Err(_) => 0,
+                                                };
+                                            } else {
+                                                warn!("Failed to process entry '{:?}', expected one value [ count ]",vect);
+                                                parsed_count = 0;
+                                            }
+                                            metric_obj.SCHEDULED_EVENTS_PROCESSED.set(parsed_count);
+                                        }
+                                        SQLResultItem::Int(vect) => {
+                                            let count;
+                                            if vect.len() == 1 {
+                                                count = vect[0];
+                                            } else {
+                                                count = 0;
+                                                warn!("Failed to process entry '{:?}', expected one value [ count ]",vect);
+                                            }
+                                            metric_obj.SCHEDULED_EVENTS_PROCESSED.set(count);
+                                        }
+                                        default => {
+                                            metric_obj.SCHEDULED_EVENTS_PROCESSED.set(0);
+                                            warn!("Failed to process entry '{:?}', expected one value [ count ]",default);
+                                        }
+                                    }
+                                } else {
+                                    warn!("Failed to process 'successful scheduled triggers' because the sql query response has incorrect format: '{:?}'",processed);
+                                }
+                            } else {
+                                info!("Result of SQL query for 'processed scheduled trigger' has failed or is empty: {:?}",processed);
+                            }
                         }
+
                     }
                     Err(e) => {
-                        warn!(
-                            "Failed to collect scheduled event check invalid response format: {}",
-                            e
-                        );
+                        warn!( "Failed to collect scheduled event check invalid response format: {}", e );
                         metric_obj.ERRORS_TOTAL.with_label_values(&["scheduled"]).inc();
                     }
                 }

--- a/metrics/src/collectors/scheduled_events.rs
+++ b/metrics/src/collectors/scheduled_events.rs
@@ -1,6 +1,6 @@
 use super::sql::*;
 use crate::{Configuration, Telemetry};
-use log::{warn, info};
+use log::{warn, info, debug};
 
 fn create_scheduled_event_request() -> SQLRequest {
     SQLRequest {
@@ -51,6 +51,7 @@ pub(crate) async fn check_scheduled_events(cfg: &Configuration,metric_obj: &Tele
         info!("Not collecting scheduled event.");
         return;
     }
+    debug!("Running SQL query for scheduled events");
     let sql_result = make_sql_request(&create_scheduled_event_request(), cfg).await;
     match sql_result {
         Ok(v) => {

--- a/metrics/src/collectors/scheduled_events.rs
+++ b/metrics/src/collectors/scheduled_events.rs
@@ -9,6 +9,7 @@ fn create_scheduled_event_request() -> SQLRequest {
                 RunSQLQuery{
                     request_type: "run_sql".to_string(),
                     args: RunSQLArgs {
+                        source: "default".to_string(),
                         cascade: false,
                         read_only: true,
                         sql: "SELECT COUNT(*) FROM hdb_catalog.hdb_scheduled_events WHERE status = 'error';".to_string()
@@ -17,6 +18,7 @@ fn create_scheduled_event_request() -> SQLRequest {
                 RunSQLQuery{
                     request_type: "run_sql".to_string(),
                     args: RunSQLArgs {
+                        source: "default".to_string(),
                         cascade: false,
                         read_only: true,
                         sql: "SELECT COUNT(*) FROM hdb_catalog.hdb_scheduled_events WHERE status = 'delivered';".to_string()
@@ -25,6 +27,7 @@ fn create_scheduled_event_request() -> SQLRequest {
                 RunSQLQuery{
                     request_type: "run_sql".to_string(),
                     args: RunSQLArgs {
+                        source: "default".to_string(),
                         cascade: false,
                         read_only: true,
                         sql: "SELECT COUNT(*) FROM hdb_catalog.hdb_scheduled_events WHERE status = 'scheduled';".to_string()
@@ -33,6 +36,7 @@ fn create_scheduled_event_request() -> SQLRequest {
                 RunSQLQuery{
                     request_type: "run_sql".to_string(),
                     args: RunSQLArgs {
+                        source: "default".to_string(),
                         cascade: false,
                         read_only: true,
                         sql: "SELECT COUNT(*) FROM hdb_catalog.hdb_scheduled_events WHERE status = 'error' or status = 'delivered';".to_string()

--- a/metrics/src/collectors/sql.rs
+++ b/metrics/src/collectors/sql.rs
@@ -9,7 +9,7 @@ pub struct SQLRequest {
     #[serde(rename = "type")]
     pub request_type: String,
     #[serde(rename = "args")]
-    pub args: std::vec::Vec<RunSQLQuery>,
+    pub args: Vec<RunSQLQuery>,
 }
 
 #[derive(Serialize)]
@@ -28,6 +28,8 @@ pub struct RunSQLArgs {
     pub read_only: bool,
     #[serde(rename = "sql")]
     pub sql: String,
+    #[serde(rename = "source")]
+    pub source: String,
 }
 
 #[derive(Deserialize)]
@@ -35,7 +37,7 @@ pub struct SQLResult {
     #[serde(rename = "result_type")]
     pub result_type: String,
     #[serde(rename = "result")]
-    pub result: std::vec::Vec<std::vec::Vec<String>>,
+    pub result: Vec<Vec<String>>,
 }
 
 pub(crate) async fn make_sql_request(request: &SQLRequest, cfg: &crate::Configuration) -> Result<Response, Whatever> {

--- a/metrics/src/logreader.rs
+++ b/metrics/src/logreader.rs
@@ -1,6 +1,6 @@
 use std::sync::mpsc;
 use std::sync::mpsc::{RecvTimeoutError,TryRecvError};
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use tokio::{
     fs::File,
     io::{AsyncBufReadExt, BufReader},
@@ -76,6 +76,7 @@ async fn process_file(file_name: &String, metric_obj: &Telemetry, file: File, sl
 
         // read data as long as there's new data available
         loop {
+            debug!("Reading line from logfile");
             match termination_rx.try_recv() {
                 Ok(_) | Err(TryRecvError::Disconnected) => {
                     return Ok(false)

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -111,6 +111,9 @@ pub(crate) struct Configuration {
 
     #[clap(name ="histogram-buckets", long = "histogram-buckets", env = "HISTOGRAM_BUCKETS", value_parser, value_delimiter(';'))]
     histogram_buckets: Vec<f64>,
+
+    #[clap(name ="concurrency-limit", long = "concurrency-limit", env = "CONCURRENCY_LIMIT", default_value = "0")]
+    concurrency_limit: usize,
 }
 
 async fn signal_handler_ctrl_c(tx: mpsc::Sender<()>) -> std::io::Result<()> {

--- a/metrics/src/telemetry.rs
+++ b/metrics/src/telemetry.rs
@@ -40,6 +40,11 @@ pub struct Telemetry {
 
 }
 
+pub enum MetricOption<'a> {
+    IntGaugeVec(&'a IntGaugeVec),
+    IntGauge(&'a IntGauge)
+}
+
 impl Telemetry {
     pub fn new(common_labels: HashMap<String, String>, histogram_buckets: Vec<f64>) -> Telemetry {
 

--- a/metrics/src/telemetry.rs
+++ b/metrics/src/telemetry.rs
@@ -265,10 +265,10 @@ impl Telemetry {
             CRON_TRIGGER_SUCCESSFUL: register_int_gauge_vec!(cron_trigger_successful_opts,&["trigger_name"]).unwrap(),
             CRON_TRIGGER_FAILED: register_int_gauge_vec!(cron_trigger_failed_opts,&["trigger_name"]).unwrap(),
 
-            EVENT_TRIGGER_PENDING: register_int_gauge_vec!(event_trigger_pending_opts,&["trigger_name"]).unwrap(),
-            EVENT_TRIGGER_PROCESSED: register_int_gauge_vec!(event_trigger_processed_opts,&["trigger_name"]).unwrap(),
-            EVENT_TRIGGER_SUCCESSFUL: register_int_gauge_vec!(event_trigger_successful_opts,&["trigger_name"]).unwrap(),
-            EVENT_TRIGGER_FAILED: register_int_gauge_vec!(event_trigger_failed_opts,&["trigger_name"]).unwrap(),
+            EVENT_TRIGGER_PENDING: register_int_gauge_vec!(event_trigger_pending_opts,&["trigger_name","database_name"]).unwrap(),
+            EVENT_TRIGGER_PROCESSED: register_int_gauge_vec!(event_trigger_processed_opts,&["trigger_name","database_name"]).unwrap(),
+            EVENT_TRIGGER_SUCCESSFUL: register_int_gauge_vec!(event_trigger_successful_opts,&["trigger_name","database_name"]).unwrap(),
+            EVENT_TRIGGER_FAILED: register_int_gauge_vec!(event_trigger_failed_opts,&["trigger_name","database_name"]).unwrap(),
 
             HEALTH_CHECK: register_int_gauge!(health_check_opts).unwrap(),
 


### PR DESCRIPTION
Before, event metrics were only calculated on default database and assuming it was Postgresql. This PR introduced concurrent request to [supported databases](https://hasura.io/docs/latest/databases/index/#event-triggers).

The list and kind of databases is obtained from the metadata endpoint, used in another metric to verify consistency. The metadata information is used to filter and build query objects. The result is either:

<details>
<summary>Postgresql</summary>

```json
[
    {
        "result_type": "TuplesOk",
        "result": [
            [
                "count",
                "trigger_name"
            ],
            [
                "6",
                "triggerExample1"
            ],
            [
                "3",
                "triggerExample2"
            ]
        ]
    },
    {
        "result_type": "TuplesOk",
        "result": [
            [
                "count",
                "trigger_name"
            ]
        ]
    },
    {
        "result_type": "TuplesOk",
        "result": [
            [
                "count",
                "trigger_name"
            ]
        ]
    },
    {
        "result_type": "TuplesOk",
        "result": [
            [
                "count",
                "trigger_name"
            ],
            [
                "6",
                "triggerExample1"
            ],
            [
                "3",
                "triggerExample2"
            ]
        ]
    }
]
```

</details>

<details><summary>MS SQL Server</summary>

```json
[
    {
        "result_type": "CommandOk",
        "result": null
    },
    {
        "result_type": "TuplesOk",
        "result": [
            [
                "",
                "trigger_name"
            ],
            [
                6,
                "triggerExample1"
            ],
            [
                3,
                "triggerExample2"
            ]
        ]
    },
    {
        "result_type": "TuplesOk",
        "result": [
            [
                "",
                "trigger_name"
            ],
            [
                6,
                "triggerExample1"
            ],
            [
                3,
                "triggerExample2"
            ]
        ]
    }
]
```

</details>

Both answers are quite similar, but differ in the display format of numeric values and how each technology (or rather, the connector) handle the empty result. In Postgresql, numeric result is represented with a string and empty result has "TuplesOk" with only the tuple headers:

```json
[...]
    {
        "result_type": "TuplesOk",
        "result": [
            [
                "count",
                "trigger_name"
            ]
        ]
    },
[...]
```

However, SQL Server's answer is like this for empty set and numeric values are represented with json int values:

```json
    {
        "result_type": "CommandOk",
        "result": null
    },
```

To be able to deserialize both correctly into the same struct in Rust, it was modified to adapt to them depending on the context.

`pub result: Option<Vec<SQLResultItem>>` for potentially emtpy results.

```rust
#[derive(Deserialize,Debug)]
#[serde(untagged)]
pub enum SQLResultItem {
    IntStr(i64,String),
    StrStr(String,String),
    Str(Vec<String>),
    Int(Vec<i64>)
}
```

for single colum result, as in

```json
    {
        "result_type": "TuplesOk",
        "result": [
            [
                "count"
            ],
            [
                "0"
            ]
        ]
    }
```

Access to databases is concurrent up to a limit, defined in the command line argument `--concurrency-limit'. By default, all databases are requested at once.

Closes #29 